### PR TITLE
Move RSalz to contributor

### DIFF
--- a/draft-ietf-shmoo-remote-fee.md
+++ b/draft-ietf-shmoo-remote-fee.md
@@ -24,12 +24,6 @@ author:
     org: Akamai
     email: jreed@akamai.com
     
-  -
-    ins: R. Salz
-    name: Rich Salz
-    org: Akamai
-    email: rsalz@akamai.com
-
 
 normative:
   RFC3935:
@@ -215,4 +209,5 @@ This document has no IANA actions.
 
 Thanks to everybody involved in the shmoo working group discussion,
 esepcially Brian Carpenter, Jason Livingood, Lars Eggert, and Charles Eckel for
-proposing concrete improvements and their in-depth reviews.
+proposing concrete improvements and their in-depth reviews, and to
+former co-author Rich Salz.


### PR DESCRIPTION
@larseggert has sent this back to the WG. Later he said the document is flawed and proposed a new outline. This is probably on me, but I don't have it in me to work on a restart (and I was only a "junior co-author" anyway, this was @mirjak's baby from day one).

Maybe this is [overtaken by events](https://www.ietf.org/blog/ietf-llc-statement-on-remote-meeting-participation/); I believe the IESG threads about wanting more clarification, which meant that more words kept being added, and those words needed clarification, resulting in loops.  And now, sentiment is for a shorter simpler document.  Good luck.
